### PR TITLE
Replace `SecretKey` based tweak methods with a new `Tweak type`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
+#[macro_use]
 pub extern crate secp256k1_zkp_sys;
 pub use secp256k1_zkp_sys as ffi;
 
@@ -95,6 +96,10 @@ pub enum Error {
     InvalidRangeProof,
     /// Bad generator
     InvalidGenerator,
+    /// Tweak must of len 32
+    InvalidTweakLength,
+    /// Tweak must be less than secp curve order
+    TweakOutOfBounds,
     /// Given bytes don't represent a valid adaptor signature
     InvalidEcdsaAdaptorSignature,
     /// Failed to decrypt an adaptor signature because of an internal error within `libsecp256k1-zkp`
@@ -120,6 +125,8 @@ impl fmt::Display for Error {
             Error::CannotRecoverAdaptorSecret => "failed to recover adaptor secret",
             Error::CannotVerifyAdaptorSignature => "failed to verify adaptor signature",
             Error::Upstream(inner) => return write!(f, "{}", inner),
+            Error::InvalidTweakLength => "Tweak must of size 32",
+            Error::TweakOutOfBounds => "Tweak must be less than secp curve order",
         };
 
         f.write_str(str)

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -1,7 +1,111 @@
 use core::{fmt, str};
-use ffi;
-use {constants, from_hex, Error, Secp256k1, SecretKey, Signing, Tag};
+use ffi::{self, CPtr};
+#[cfg(feature = "rand")]
+use rand::Rng;
+use {constants, from_hex, Error, Secp256k1, Signing, Tag};
 
+/// Represents a blinding factor/Tweak on secp256k1 curve
+///
+/// Contrary to a [`crate::SecretKey`], the value 0 is also a valid tweak.
+/// Values outside secp curve order are invalid tweaks.
+#[derive(Default, Hash)]
+pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
+impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
+
+/// The zero Tweak
+pub const ZERO_TWEAK: Tweak = Tweak([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+]);
+
+impl fmt::Debug for Tweak {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Tweak(")?;
+        for i in self[..].iter().cloned() {
+            write!(f, "{:02x}", i)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl fmt::LowerHex for Tweak {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for ch in &self.0[..] {
+            write!(f, "{:02x}", *ch)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Tweak {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(self, f)
+    }
+}
+
+impl str::FromStr for Tweak {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Tweak, Error> {
+        let mut res = [0; constants::SECRET_KEY_SIZE];
+        match from_hex(s, &mut res) {
+            Ok(constants::SECRET_KEY_SIZE) => Tweak::from_inner(res),
+            _ => Err(Error::InvalidTweakLength),
+        }
+    }
+}
+
+impl Tweak {
+    /// Generate a new random Tweak
+    #[cfg(feature = "rand")]
+    pub fn new<R: Rng + ?Sized>(rng: &mut R) -> Tweak {
+        let mut ret = [0u8; constants::SECRET_KEY_SIZE];
+        rng.fill_bytes(&mut ret);
+        Tweak(ret)
+    }
+
+    /// Converts a byte slice to a Tweak
+    /// Fails if tweak is not 32 bytes or if tweak is outside secp curve order
+    #[inline]
+    pub fn from_slice(data: &[u8]) -> Result<Tweak, Error> {
+        match data.len() {
+            constants::SECRET_KEY_SIZE => {
+                let mut ret = [0; constants::SECRET_KEY_SIZE];
+                unsafe {
+                    if ffi::secp256k1_ec_seckey_verify(
+                        ffi::secp256k1_context_no_precomp,
+                        data.as_ref().as_c_ptr(),
+                    ) == 0
+                    {
+                        if data.iter().all(|x| *x == 0) {
+                            return Ok(Tweak(ret));
+                        }
+                        return Err(Error::TweakOutOfBounds);
+                    }
+                }
+                ret[..].copy_from_slice(data);
+                Ok(Tweak(ret))
+            }
+            _ => Err(Error::InvalidTweakLength),
+        }
+    }
+
+    /// Converts a `SECRET_KEY_SIZE`(32)- array to a tweak
+    #[inline]
+    pub fn from_inner(data: [u8; 32]) -> Result<Tweak, Error> {
+        unsafe {
+            if ffi::secp256k1_ec_seckey_verify(
+                ffi::secp256k1_context_no_precomp,
+                data.as_ref().as_c_ptr(),
+            ) == 0
+            {
+                if data.iter().all(|x| *x == 0) {
+                    return Ok(Tweak(data));
+                }
+                return Err(Error::TweakOutOfBounds);
+            }
+        }
+        Ok(Tweak(data))
+    }
+}
 /// Represents a generator on the secp256k1 curve.
 ///
 /// A generator is a public key internally but has a slightly different serialization with the first byte being tweaked.
@@ -47,11 +151,7 @@ impl Generator {
 
     /// Creates a new [`Generator`] by blinding a [`Tag`] using the given blinding factor.
     /// Use [Generator::new_unblinded] for creating a [`Generator`] with zero blinding factor
-    pub fn new_blinded<C: Signing>(
-        secp: &Secp256k1<C>,
-        tag: Tag,
-        blinding_factor: SecretKey,
-    ) -> Self {
+    pub fn new_blinded<C: Signing>(secp: &Secp256k1<C>, tag: Tag, blinding_factor: Tweak) -> Self {
         let mut generator = unsafe { ffi::PublicKey::new() };
 
         let ret = unsafe {
@@ -68,8 +168,7 @@ impl Generator {
     }
 
     /// Creates a new unblinded [`Generator`] by from [`Tag`]
-    /// The [Generator::new_blinded] cannot be used for zero blind because
-    /// zero value is not permitted for [`SecretKey`] type.
+    /// Same as using zero [`Tweak`] with [`Generator::new_blinded`]
     pub fn new_unblinded<C: Signing>(secp: &Secp256k1<C>, tag: Tag) -> Self {
         let mut generator = unsafe { ffi::PublicKey::new() };
         let zero_bf = [0u8; constants::SECRET_KEY_SIZE];

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -170,20 +170,7 @@ impl Generator {
     /// Creates a new unblinded [`Generator`] by from [`Tag`]
     /// Same as using zero [`Tweak`] with [`Generator::new_blinded`]
     pub fn new_unblinded<C: Signing>(secp: &Secp256k1<C>, tag: Tag) -> Self {
-        let mut generator = unsafe { ffi::PublicKey::new() };
-        let zero_bf = [0u8; constants::SECRET_KEY_SIZE];
-
-        let ret = unsafe {
-            ffi::secp256k1_generator_generate_blinded(
-                *secp.ctx(),
-                &mut generator,
-                tag.into_inner().as_ptr(),
-                zero_bf.as_ptr(),
-            )
-        };
-        assert_eq!(ret, 1);
-
-        Generator(generator)
+        Generator::new_blinded(secp, tag, ZERO_TWEAK)
     }
 
     /// Extracts the internal representation of this generator.

--- a/src/zkp/pedersen.rs
+++ b/src/zkp/pedersen.rs
@@ -1,6 +1,6 @@
 use core::{fmt, slice, str};
 use ffi;
-use {constants, from_hex, Error, Generator, Secp256k1, Signing, Tweak, ZERO_TWEAK};
+use {from_hex, Error, Generator, Secp256k1, Signing, Tweak, ZERO_TWEAK};
 
 /// Represents a commitment to a single u64 value.
 #[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
@@ -80,21 +80,7 @@ impl PedersenCommitment {
         value: u64,
         generator: Generator,
     ) -> Self {
-        let mut commitment = ffi::PedersenCommitment::default();
-        let zero_bf = [0u8; constants::SECRET_KEY_SIZE];
-
-        let ret = unsafe {
-            ffi::secp256k1_pedersen_commit(
-                *secp.ctx(),
-                &mut commitment,
-                zero_bf.as_ptr(),
-                value,
-                generator.as_inner(),
-            )
-        };
-        assert_eq!(ret, 1, "failed to create pedersen commitment");
-
-        PedersenCommitment(commitment)
+        PedersenCommitment::new(secp, value, ZERO_TWEAK ,generator)
     }
 
     pub(crate) fn as_inner(&self) -> &ffi::PedersenCommitment {

--- a/src/zkp/pedersen.rs
+++ b/src/zkp/pedersen.rs
@@ -1,6 +1,6 @@
 use core::{fmt, slice, str};
 use ffi;
-use {constants, from_hex, key::ONE_KEY, Error, Generator, Secp256k1, SecretKey, Signing};
+use {constants, from_hex, Error, Generator, Secp256k1, Signing, Tweak, ZERO_TWEAK};
 
 /// Represents a commitment to a single u64 value.
 #[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
@@ -51,7 +51,7 @@ impl PedersenCommitment {
     pub fn new<C: Signing>(
         secp: &Secp256k1<C>,
         value: u64,
-        blinding_factor: SecretKey,
+        blinding_factor: Tweak,
         generator: Generator,
     ) -> Self {
         let mut commitment = ffi::PedersenCommitment::default();
@@ -75,8 +75,6 @@ impl PedersenCommitment {
 
     /// Create a new [`PedersenCommitment`] that commits to the given value
     /// with a zero blinding factor and the [`Generator`].
-    /// The [PedersenCommitment::new] cannot be used for zero blind because
-    /// zero value is not permitted for [`SecretKey`] type.
     pub fn new_unblinded<C: Signing>(
         secp: &Secp256k1<C>,
         value: u64,
@@ -116,18 +114,14 @@ pub struct CommitmentSecrets {
     /// The value that is committed to.
     pub value: u64,
     /// The blinding factor used when committing to the value.
-    pub value_blinding_factor: SecretKey,
+    pub value_blinding_factor: Tweak,
     /// The blinding factor used when producing the [`Generator`] that is necessary to commit to the value.
-    pub generator_blinding_factor: SecretKey,
+    pub generator_blinding_factor: Tweak,
 }
 
 impl CommitmentSecrets {
     /// Constructor.
-    pub fn new(
-        value: u64,
-        value_blinding_factor: SecretKey,
-        generator_blinding_factor: SecretKey,
-    ) -> Self {
+    pub fn new(value: u64, value_blinding_factor: Tweak, generator_blinding_factor: Tweak) -> Self {
         CommitmentSecrets {
             value,
             value_blinding_factor,
@@ -140,11 +134,11 @@ impl CommitmentSecrets {
 pub fn compute_adaptive_blinding_factor<C: Signing>(
     secp: &Secp256k1<C>,
     value: u64,
-    generator_blinding_factor: SecretKey,
+    generator_blinding_factor: Tweak,
     set_a: &[CommitmentSecrets],
     set_b: &[CommitmentSecrets],
-) -> SecretKey {
-    let value_blinding_factor_placeholder = ONE_KEY; // this placeholder will be filled with the generated blinding factor
+) -> Tweak {
+    let value_blinding_factor_placeholder = ZERO_TWEAK; // this placeholder will be filled with the generated blinding factor
 
     let (mut values, mut secrets) = set_a
         .iter()
@@ -178,7 +172,7 @@ pub fn compute_adaptive_blinding_factor<C: Signing>(
 
     let last = vbf.last().expect("this vector is never empty");
     let slice = unsafe { slice::from_raw_parts(*last, 32) };
-    SecretKey::from_slice(slice).expect("data is always a valid secret key")
+    Tweak::from_slice(slice).expect("data is always 32 bytes")
 }
 
 /// Verifies that the sum of the committed values within the commitments of both sets is equal.
@@ -306,8 +300,8 @@ mod tests {
         pub fn random(value: u64) -> Self {
             Self {
                 value,
-                value_blinding_factor: SecretKey::new(&mut thread_rng()),
-                generator_blinding_factor: SecretKey::new(&mut thread_rng()),
+                value_blinding_factor: Tweak::new(&mut thread_rng()),
+                generator_blinding_factor: Tweak::new(&mut thread_rng()),
             }
         }
 
@@ -359,7 +353,7 @@ mod tests {
         let secrets_3 = CommitmentSecrets::random(1000);
         let commitment_3 = secrets_3.commit(tag_1);
 
-        let tbf_4 = SecretKey::new(&mut thread_rng());
+        let tbf_4 = Tweak::new(&mut thread_rng());
         let blinded_tag_4 = Generator::new_blinded(SECP256K1, tag_2, tbf_4);
         let vbf_4 = compute_adaptive_blinding_factor(
             SECP256K1,

--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -4,7 +4,7 @@ use Error;
 use Generator;
 use PedersenCommitment;
 use Verification;
-use {ffi, Secp256k1, SecretKey, Signing};
+use {ffi, Secp256k1, SecretKey, Signing, Tweak};
 
 /// Represents a range proof.
 ///
@@ -66,7 +66,7 @@ impl RangeProof {
         min_value: u64,
         commitment: PedersenCommitment,
         value: u64,
-        commitment_blinding: SecretKey,
+        commitment_blinding: Tweak,
         message: &[u8],
         additional_commitment: &[u8],
         sk: SecretKey,
@@ -185,7 +185,7 @@ impl RangeProof {
 
         let opening = Opening {
             value,
-            blinding_factor: SecretKey::from_slice(&blinding_factor)?,
+            blinding_factor: Tweak::from_slice(&blinding_factor)?,
             message: message[..message_length].into(),
         };
 
@@ -276,7 +276,7 @@ pub struct Opening {
     /// The value that the prover originally committed to in the Pedersen commitment.
     pub value: u64,
     /// The blinding factor that was used to create the Pedersen commitment of above value.
-    pub blinding_factor: SecretKey,
+    pub blinding_factor: Tweak,
     /// The message that was embedded by the prover.
     pub message: Box<[u8]>,
 }

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -13,7 +13,7 @@ pub struct SurjectionProof {
 mod with_rand {
     use super::*;
     use rand::Rng;
-    use {SecretKey, Signing, Tag};
+    use {Signing, Tag, Tweak};
 
     impl SurjectionProof {
         /// Prove that a given tag - when blinded - is contained within another set of blinded tags.
@@ -24,8 +24,8 @@ mod with_rand {
             secp: &Secp256k1<C>,
             rng: &mut R,
             codomain_tag: Tag,
-            codomain_blinding_factor: SecretKey,
-            domain: &[(Generator, Tag, SecretKey)],
+            codomain_blinding_factor: Tweak,
+            domain: &[(Generator, Tag, Tweak)],
         ) -> Result<SurjectionProof, Error> {
             let mut proof = ffi::SurjectionProof::new();
 
@@ -172,7 +172,7 @@ impl SurjectionProof {
 mod tests {
     use super::*;
     use rand::thread_rng;
-    use {SecretKey, Tag, SECP256K1};
+    use {Tag, Tweak, SECP256K1};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(parsed, proof)
     }
 
-    fn random_blinded_tag() -> (Tag, Generator, SecretKey) {
+    fn random_blinded_tag() -> (Tag, Generator, Tweak) {
         let tag = Tag::random();
 
         let (blinded_tag, bf) = blind_tag(tag);
@@ -240,8 +240,8 @@ mod tests {
         (tag, blinded_tag, bf)
     }
 
-    fn blind_tag(tag: Tag) -> (Generator, SecretKey) {
-        let bf = SecretKey::new(&mut thread_rng());
+    fn blind_tag(tag: Tag) -> (Generator, Tweak) {
+        let bf = Tweak::new(&mut thread_rng());
         let blinded_tag = Generator::new_blinded(SECP256K1, tag, bf);
 
         (blinded_tag, bf)


### PR DESCRIPTION
While implementing additional validation in rust-elements, I realized that we need have zero value tweaks/blinding factors. We need for 
I created a temporary workaround in #14, but unfortunately, that's not entirely enough. We also need tweaks for other functions like computing the last blinding factor. This currently has functions that assume `SecretKey` type blinding factors that are not compatible with explicit assets. 