### PR TITLE
Implement AsRef for EcdsaAdaptorSignature

### DIFF
--- a/src/zkp/ecdsa_adaptor.rs
+++ b/src/zkp/ecdsa_adaptor.rs
@@ -61,6 +61,12 @@ impl CPtr for EcdsaAdaptorSignature {
     }
 }
 
+impl AsRef<[u8]> for EcdsaAdaptorSignature {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl EcdsaAdaptorSignature {
     /// Creates an [`EcdsaAdaptorSignature`] directly from a slice
     #[inline]


### PR DESCRIPTION
While doing some serialization work I noticed that I had omitted to implement something to get an `EcdsaAdaptorSignature` as a slice. As implementing `AsRef` seems to be what is done in rust-secp256k1 I went with that but let me know if there is another preferred way.