### PR TITLE
Remove explicit bitcoin_hashes dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add ECDSA adaptor signatures
 
 # 0.2.1 - 2021-04-13
+
 - Fix bug in Pedersen Commitment deserialization.
 
 # 0.2.0 - 2021-01-06
@@ -22,5 +23,3 @@
 # 0.1.0 - 2019-06-03
 
 - Initial release with bindings to Schnorr signatures
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Rename `secp256k1_zkp::bitcoin_hashes` module to `secp256k1_zkp::hashes`.
+
 # 0.4.0 - 2021-05-04
 
 - Changed several zkp APIs to use `Tweak` type instead of `SecretKey` type to allow modelling of zero tweaks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Rename `secp256k1_zkp::bitcoin_hashes` module to `secp256k1_zkp::hashes`.
+- Rename feature `hashes` to `bitcoin_hashes` to align with `rust-secp256k1`.
 
 # 0.4.0 - 2021-05-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,13 @@ rand-std = ["rand/std", "secp256k1/rand-std"]
 recovery = ["secp256k1-zkp-sys/recovery", "secp256k1/recovery"]
 lowmemory = ["secp256k1-zkp-sys/lowmemory", "secp256k1/lowmemory"]
 global-context = ["std", "rand-std", "secp256k1/global-context"]
-hashes = ["bitcoin_hashes", "secp256k1/bitcoin_hashes"]
+hashes = ["secp256k1/bitcoin_hashes"]
 use-serde = ["serde", "secp256k1/serde"]
 use-rand = ["rand", "secp256k1/rand"]
 
 [dependencies]
 secp256k1 = "0.20.0"
 secp256k1-zkp-sys = { version = "0.4.0", default-features = false, path = "./secp256k1-zkp-sys" }
-bitcoin_hashes = { version = "0.9", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
@@ -40,7 +39,6 @@ serde = { version = "1.0", default-features = false, optional = true }
 rand = "0.6"
 rand_core = "0.4"
 serde_test = "1.0"
-bitcoin_hashes = "0.9"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand-std = ["rand/std", "secp256k1/rand-std"]
 recovery = ["secp256k1-zkp-sys/recovery", "secp256k1/recovery"]
 lowmemory = ["secp256k1-zkp-sys/lowmemory", "secp256k1/lowmemory"]
 global-context = ["std", "rand-std", "secp256k1/global-context"]
-hashes = ["secp256k1/bitcoin_hashes"]
+bitcoin_hashes = ["secp256k1/bitcoin_hashes"]
 use-serde = ["serde", "secp256k1/serde"]
 use-rand = ["rand", "secp256k1/rand"]
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="hashes global-context lowmemory use-rand rand-std recovery use-serde"
+FEATURES="bitcoin_hashes global-context lowmemory use-rand rand-std recovery use-serde"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/secp256k1-zkp-sys/CHANGELOG.md
+++ b/secp256k1-zkp-sys/CHANGELOG.md
@@ -6,6 +6,3 @@
 # 0.1.0 - 2019-06-03
 
 - Initial release with bindings to Schnorr signatures
-
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use secp256k1_zkp_sys as ffi;
 
 extern crate secp256k1;
 
-#[cfg(feature = "hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 pub use secp256k1::bitcoin_hashes as hashes;
 #[cfg(any(test, feature = "std"))]
 extern crate core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use secp256k1_zkp_sys as ffi;
 extern crate secp256k1;
 
 #[cfg(feature = "hashes")]
-pub extern crate bitcoin_hashes;
+pub use secp256k1::bitcoin_hashes as hashes;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 #[cfg(any(test, feature = "rand"))]


### PR DESCRIPTION
Instead of depending in bitcoin_hashes explicitly, we can just re-export the module from `secp256k1`. This should simplify future version upgrades.
