### PR TITLE
Use newly renamed bitcoin_hashes feature everywhere

### DIFF
--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -198,7 +198,7 @@ impl RangeProof {
     }
 }
 
-#[cfg(feature = "hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 impl ::core::fmt::Display for RangeProof {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         use bitcoin_hashes::hex::format_hex;
@@ -209,7 +209,7 @@ impl ::core::fmt::Display for RangeProof {
 
 // TODO: Macrofy (de)serialization
 
-#[cfg(all(feature = "serde", feature = "hashes"))]
+#[cfg(all(feature = "serde", feature = "bitcoin_hashes"))]
 impl ::serde::Serialize for RangeProof {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
@@ -220,7 +220,7 @@ impl ::serde::Serialize for RangeProof {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hashes"))]
+#[cfg(all(feature = "serde", feature = "bitcoin_hashes"))]
 impl<'de> ::serde::Deserialize<'de> for RangeProof {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<RangeProof, D::Error> {
         use core::fmt;

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -178,7 +178,7 @@ impl SurjectionProof {
     }
 }
 
-#[cfg(feature = "hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 impl ::core::fmt::Display for SurjectionProof {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         use bitcoin_hashes::hex::format_hex;
@@ -189,7 +189,7 @@ impl ::core::fmt::Display for SurjectionProof {
 
 // TODO: Macrofy (de)serialization
 
-#[cfg(all(feature = "serde", feature = "hashes"))]
+#[cfg(all(feature = "serde", feature = "bitcoin_hashes"))]
 impl ::serde::Serialize for SurjectionProof {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
@@ -200,7 +200,7 @@ impl ::serde::Serialize for SurjectionProof {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hashes"))]
+#[cfg(all(feature = "serde", feature = "bitcoin_hashes"))]
 impl<'de> ::serde::Deserialize<'de> for SurjectionProof {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<SurjectionProof, D::Error> {
         use core::fmt;


### PR DESCRIPTION
We forgot to rename all instances of `hashes` to `bitcoin_hashes` in patch e5d82e728a0bcc1d81b0824e87e70efcf309b9b0.