### PR TITLE
Encrypt ECDSA signatures in release builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,3 +103,32 @@ jobs:
           DO_FEATURE_MATRIX: true
         run: ./contrib/test.sh
 
+  ReleaseTests:
+    name: Release tests with global context enabled
+    strategy:
+      matrix:
+        rust:
+          - 1.29.0
+          - beta
+          - stable
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Pin cc if rust 1.29
+        if: matrix.rust == '1.29.0'
+        run: cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose
+      - name: Running cargo in release mode
+        run: cargo test --features="global-context" --release

--- a/src/zkp/ecdsa_adaptor.rs
+++ b/src/zkp/ecdsa_adaptor.rs
@@ -167,19 +167,18 @@ impl EcdsaAdaptorSignature {
     ) -> EcdsaAdaptorSignature {
         let mut adaptor_sig = ffi::EcdsaAdaptorSignature::new();
 
-        unsafe {
-            debug_assert!(
-                ffi::secp256k1_ecdsa_adaptor_encrypt(
-                    *secp.ctx(),
-                    &mut adaptor_sig,
-                    sk.as_c_ptr(),
-                    enckey.as_c_ptr(),
-                    msg.as_c_ptr(),
-                    ffi::secp256k1_nonce_function_ecdsa_adaptor,
-                    ptr::null_mut(),
-                ) == 1
-            );
+        let res = unsafe {
+            ffi::secp256k1_ecdsa_adaptor_encrypt(
+                *secp.ctx(),
+                &mut adaptor_sig,
+                sk.as_c_ptr(),
+                enckey.as_c_ptr(),
+                msg.as_c_ptr(),
+                ffi::secp256k1_nonce_function_ecdsa_adaptor,
+                ptr::null_mut(),
+            )
         };
+        debug_assert_eq!(res, 1);
 
         EcdsaAdaptorSignature(adaptor_sig)
     }
@@ -197,19 +196,19 @@ impl EcdsaAdaptorSignature {
     ) -> EcdsaAdaptorSignature {
         let mut adaptor_sig = ffi::EcdsaAdaptorSignature::new();
 
-        unsafe {
-            debug_assert!(
-                ffi::secp256k1_ecdsa_adaptor_encrypt(
-                    *secp.ctx(),
-                    &mut adaptor_sig,
-                    sk.as_c_ptr(),
-                    enckey.as_c_ptr(),
-                    msg.as_c_ptr(),
-                    ffi::secp256k1_nonce_function_ecdsa_adaptor,
-                    aux_rand.as_c_ptr() as *mut ffi::types::c_void,
-                ) == 1
-            );
+        let res = unsafe {
+            ffi::secp256k1_ecdsa_adaptor_encrypt(
+                *secp.ctx(),
+                &mut adaptor_sig,
+                sk.as_c_ptr(),
+                enckey.as_c_ptr(),
+                msg.as_c_ptr(),
+                ffi::secp256k1_nonce_function_ecdsa_adaptor,
+                aux_rand.as_c_ptr() as *mut ffi::types::c_void,
+            )
         };
+        debug_assert_eq!(res, 1);
+
         EcdsaAdaptorSignature(adaptor_sig)
     }
 


### PR DESCRIPTION
First commit adds a CI job that demonstrate the failing tests in release build (with relevant feature flag enabled needed for the tests to run).