### PR TITLE
Remove `Hash` implementations for `zkp` types

### DIFF
--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -490,12 +490,6 @@ impl Default for Tag {
     }
 }
 
-impl hash::Hash for Tag {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
-    }
-}
-
 impl From<[u8; 32]> for Tag {
     fn from(bytes: [u8; 32]) -> Self {
         Tag(bytes)
@@ -523,12 +517,6 @@ impl PedersenCommitment {
 impl Default for PedersenCommitment {
     fn default() -> Self {
         PedersenCommitment::new()
-    }
-}
-
-impl hash::Hash for PedersenCommitment {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
     }
 }
 

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -8,7 +8,7 @@ use {constants, from_hex, Error, Secp256k1, Signing, Tag};
 ///
 /// Contrary to a [`crate::SecretKey`], the value 0 is also a valid tweak.
 /// Values outside secp curve order are invalid tweaks.
-#[derive(Default, Hash)]
+#[derive(Default)]
 pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
 


### PR DESCRIPTION
A breaking change was inadvertently introduced with the release of `rust-secp256k1-sys:0.4.2`. 

Anyone who had used `impl_array_newtype` for type `T` and had also implemented `hash::Hash` on `T` before version `0.4.2` would now come across a "conflicting implementations error" on version `0.4.2`.