### PR TITLE
[backport -sys 0.4] Fix sys duplicate impl + release -sys v0.4.1

### DIFF
--- a/secp256k1-zkp-sys/CHANGELOG.md
+++ b/secp256k1-zkp-sys/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# 0.4.1 - 2022-04-07
+
+- backport compile error fix from 0.5.0
+
 # 0.2.0 - 2021-01-06
 
 - Completely replaced with https://github.com/comit-network/rust-secp256k1-zkp/ which has

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-zkp-sys"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>",

--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -434,12 +434,6 @@ impl Default for Tag {
     }
 }
 
-impl hash::Hash for Tag {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
-    }
-}
-
 impl From<[u8; 32]> for Tag {
     fn from(bytes: [u8; 32]) -> Self {
         Tag(bytes)
@@ -467,12 +461,6 @@ impl PedersenCommitment {
 impl Default for PedersenCommitment {
     fn default() -> Self {
         PedersenCommitment::new()
-    }
-}
-
-impl hash::Hash for PedersenCommitment {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
     }
 }
 

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -8,7 +8,7 @@ use {constants, from_hex, Error, Secp256k1, Signing, Tag};
 ///
 /// Contrary to a [`crate::SecretKey`], the value 0 is also a valid tweak.
 /// Values outside secp curve order are invalid tweaks.
-#[derive(Default, Hash)]
+#[derive(Default)]
 pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
 


### PR DESCRIPTION
The -sys v0.4.0 version currently doesn't build. This backports the fix into a new 0.4.1 version. I created a release branch for that.