### PR TITLE
ffi: fix signature of whitelist_sign

### DIFF
--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -1,5 +1,5 @@
 use core::{fmt, hash};
-use {types::*, Context, NonceFn, PublicKey, Signature};
+use {types::*, Context, PublicKey, Signature};
 
 /// Rangeproof maximum length
 pub const RANGEPROOF_MAX_LENGTH: size_t = 5134;
@@ -374,8 +374,6 @@ extern "C" {
         online_seckey: *const c_uchar,
         summed_seckey: *const c_uchar,
         index: size_t,
-        noncefp: NonceFn,
-        noncedata: *mut c_void,
     ) -> c_int;
 
     #[cfg_attr(

--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -5,8 +5,6 @@
 #[cfg(feature = "std")]
 use std::{fmt, str};
 
-use core::ptr;
-
 use ffi::CPtr;
 #[cfg(feature = "std")]
 use from_hex;
@@ -94,8 +92,6 @@ impl WhitelistSignature {
                 online_secret_key.as_ptr(),
                 summed_secret_key.as_ptr(),
                 key_index,
-                None,
-                ptr::null_mut(),
             )
         };
         if ret != 1 {


### PR DESCRIPTION
The signature of whitelist_sign in our FFI bindings did not match the signature in the C libarry.

Noticed when running local tests on #55. Apparently wasm-pack notices stuff like this now and errors out :) 