### PR TITLE
Update rust-secp256k1 and rust-secp256k1-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ autoexamples = false # Remove when edition 2018 https://github.com/rust-lang/car
 features = [ "use-rand", "rand-std", "use-serde", "recovery" ]
 
 [features]
-unstable = ["recovery", "rand-std", "secp256k1/unstable"]
 default = ["std"]
 std = ["secp256k1-zkp-sys/std", "secp256k1/std"]
 rand-std = ["rand/std", "secp256k1/rand-std"]
@@ -30,7 +29,7 @@ use-serde = ["serde", "secp256k1/serde"]
 use-rand = ["rand", "secp256k1/rand"]
 
 [dependencies]
-secp256k1 = "0.22.1"
+secp256k1 = "0.24.0"
 secp256k1-zkp-sys = { version = "0.6.0", default-features = false, path = "./secp256k1-zkp-sys" }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -23,7 +23,7 @@ features = [ "recovery", "lowmemory" ]
 cc = "1.0.28"
 
 [dependencies]
-secp256k1-sys = "0.5"
+secp256k1-sys = "0.6"
 
 [features]
 default = ["std"]

--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -8,7 +8,7 @@ use std::{fmt, str};
 use ffi::CPtr;
 #[cfg(feature = "std")]
 use from_hex;
-use {ffi, secp256k1, Error, PublicKey, Secp256k1, SecretKey, Signing, Verification};
+use {ffi, Error, PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 /// A whitelist ring signature.
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -85,8 +85,8 @@ impl WhitelistSignature {
                 *secp.ctx(),
                 &mut sig,
                 // These two casts are legit because PublicKey has repr(transparent).
-                online_keys.as_c_ptr() as *const secp256k1::secp256k1_sys::PublicKey,
-                offline_keys.as_c_ptr() as *const secp256k1::secp256k1_sys::PublicKey,
+                online_keys.as_c_ptr() as *const ffi::PublicKey,
+                offline_keys.as_c_ptr() as *const ffi::PublicKey,
                 n_keys,
                 whitelist_key.as_c_ptr(),
                 online_secret_key.as_ptr(),
@@ -119,8 +119,8 @@ impl WhitelistSignature {
                 *secp.ctx(),
                 &self.0,
                 // These two casts are legit because PublicKey has repr(transparent).
-                online_keys.as_c_ptr() as *const secp256k1::secp256k1_sys::PublicKey,
-                offline_keys.as_c_ptr() as *const secp256k1::secp256k1_sys::PublicKey,
+                online_keys.as_c_ptr() as *const ffi::PublicKey,
+                offline_keys.as_c_ptr() as *const ffi::PublicKey,
                 n_keys,
                 whitelist_key.as_c_ptr(),
             )


### PR DESCRIPTION
Closes #57 

I removed the `unstable` feature because [it was removed from rust-secp256k1](https://github.com/rust-bitcoin/rust-secp256k1/commit/71b47d127396e1e246fb06fd86b2ad3b920304ee). Let me know if we should keep this.

`secp256k1::secp256k1_sys` re-export was removed, but it seems that `ffi` re-export is the same thing?