### PR TITLE
Update to secp 0.26 and secp-sys 0.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,11 +74,9 @@ jobs:
           - 1.41.1
           - beta
           - stable
-        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
+        os: [ ubuntu-latest, macos-latest ]
+        exclude:
+          - rust: 1.41.1
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -108,11 +106,9 @@ jobs:
           - 1.41.1
           - beta
           - stable
-        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
+        os: [ ubuntu-latest, macos-latest ]
+        exclude:
+          - rust: 1.41.1
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ use-serde = ["serde", "secp256k1/serde"]
 use-rand = ["rand", "secp256k1/rand"]
 
 [dependencies]
-secp256k1 = "0.24.0"
+secp256k1 = "0.26.0"
 secp256k1-zkp-sys = { version = "0.7.0", default-features = false, path = "./secp256k1-zkp-sys" }
 rand = { version = "0.8", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -23,7 +23,7 @@ features = [ "recovery", "lowmemory" ]
 cc = "1.0.28"
 
 [dependencies]
-secp256k1-sys = "0.6.0"
+secp256k1-sys = "0.8.0"
 
 [features]
 default = ["std"]

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -8,7 +8,8 @@ use rand::Rng;
 ///
 /// Contrary to a [`crate::SecretKey`], the value 0 is also a valid tweak.
 /// Values outside secp curve order are invalid tweaks.
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
+#[cfg_attr(not(fuzzing), derive(Eq, PartialEq))]
 pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
 
@@ -156,10 +157,10 @@ impl Generator {
 
         let ret = unsafe {
             ffi::secp256k1_generator_generate_blinded(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 &mut generator,
-                tag.into_inner().as_ptr(),
-                blinding_factor.as_ptr(),
+                tag.into_inner().as_c_ptr(),
+                blinding_factor.as_c_ptr(),
             )
         };
         assert_eq!(ret, 1);

--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -1,3 +1,5 @@
+use ffi::CPtr;
+
 use crate::ffi::RANGEPROOF_MAX_LENGTH;
 use crate::from_hex;
 use crate::Error;
@@ -81,13 +83,13 @@ impl RangeProof {
 
         let ret = unsafe {
             ffi::secp256k1_rangeproof_sign(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 proof.as_mut_ptr(),
                 &mut proof_length,
                 min_value,
                 commitment.as_inner(),
-                commitment_blinding.as_ptr(),
-                sk.as_ptr(),
+                commitment_blinding.as_c_ptr(),
+                sk.as_c_ptr(),
                 exp,
                 min_bits as i32,
                 value,
@@ -123,7 +125,7 @@ impl RangeProof {
 
         let ret = unsafe {
             ffi::secp256k1_rangeproof_verify(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 &mut min_value,
                 &mut max_value,
                 commitment.as_inner(),
@@ -164,12 +166,12 @@ impl RangeProof {
 
         let ret = unsafe {
             ffi::secp256k1_rangeproof_rewind(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 blinding_factor.as_mut_ptr(),
                 &mut value,
                 message.as_mut_ptr(),
                 &mut message_length,
-                sk.as_ptr(),
+                sk.as_c_ptr(),
                 &mut min_value,
                 &mut max_value,
                 commitment.as_inner(),

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -15,6 +15,7 @@ pub struct SurjectionProof {
 mod with_rand {
     use super::*;
     use crate::{Signing, Tag, Tweak};
+    use ffi::CPtr;
     use rand::Rng;
 
     impl SurjectionProof {
@@ -49,7 +50,7 @@ mod with_rand {
 
             let ret = unsafe {
                 ffi::secp256k1_surjectionproof_initialize(
-                    *secp.ctx(),
+                    secp.ctx().as_ptr(),
                     &mut proof,
                     &mut domain_index,
                     domain_tags.as_ptr(),
@@ -70,7 +71,7 @@ mod with_rand {
 
             let ret = unsafe {
                 ffi::secp256k1_surjectionproof_generate(
-                    *secp.ctx(),
+                    secp.ctx().as_ptr(),
                     &mut proof,
                     domain_blinded_tags.as_ptr(),
                     domain.len(),
@@ -80,8 +81,8 @@ mod with_rand {
                         .get(domain_index)
                         .ok_or(Error::CannotProveSurjection)?
                         .2
-                        .as_ptr(), // TODO: Return dedicated error here?
-                    codomain_blinding_factor.as_ptr(),
+                        .as_c_ptr(), // TODO: Return dedicated error here?
+                    codomain_blinding_factor.as_c_ptr(),
                 )
             };
 
@@ -168,7 +169,7 @@ impl SurjectionProof {
 
         let ret = unsafe {
             ffi::secp256k1_surjectionproof_verify(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 &self.inner,
                 domain_blinded_tags.as_ptr(),
                 domain_blinded_tags.len(),

--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -82,15 +82,15 @@ impl WhitelistSignature {
         let mut sig = ffi::WhitelistSignature::default();
         let ret = unsafe {
             ffi::secp256k1_whitelist_sign(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 &mut sig,
                 // These two casts are legit because PublicKey has repr(transparent).
                 online_keys.as_c_ptr() as *const ffi::PublicKey,
                 offline_keys.as_c_ptr() as *const ffi::PublicKey,
                 n_keys,
                 whitelist_key.as_c_ptr(),
-                online_secret_key.as_ptr(),
-                summed_secret_key.as_ptr(),
+                online_secret_key.as_c_ptr(),
+                summed_secret_key.as_c_ptr(),
                 key_index,
             )
         };
@@ -116,7 +116,7 @@ impl WhitelistSignature {
 
         let ret = unsafe {
             ffi::secp256k1_whitelist_verify(
-                *secp.ctx(),
+                secp.ctx().as_ptr(),
                 &self.0,
                 // These two casts are legit because PublicKey has repr(transparent).
                 online_keys.as_c_ptr() as *const ffi::PublicKey,


### PR DESCRIPTION
This PR updates the rust-secp256k1(-sys) dependencies to latest released ones. I tried to mimic what was done upstream. Regarding the trait implementations (`Eq`, `PartialEq`,...), since the sys types in this crate don't seem to have `serialize` functions I felt like it was ok to just derive then but please correct me if that's wrong.